### PR TITLE
Use ansible inventory_hostname instead of requiring a variable

### DIFF
--- a/tasks/provision_dellos10.yaml
+++ b/tasks/provision_dellos10.yaml
@@ -3,7 +3,7 @@
  - name: "Generating ACL configuration for dellos10"
    template:
       src: dellos10_acl.j2
-      dest: "{{ build_dir }}/acl10_{{ hostname }}.conf.part"
+      dest: "{{ build_dir }}/acl10_{{ inventory_hostname }}.conf.part"
    when: (ansible_network_os is defined and ansible_network_os == "dellos10") and ((dellos_cfg_generate | default('False')) | bool)
 #   notify: save config os10
    register: generate_output

--- a/tasks/provision_dellos6.yaml
+++ b/tasks/provision_dellos6.yaml
@@ -3,7 +3,7 @@
  - name: "Generating ACL configuration for dellos6"
    template:
       src: dellos6_acl.j2
-      dest: "{{ build_dir }}/acl6_{{ hostname }}.conf.part"
+      dest: "{{ build_dir }}/acl6_{{ inventory_hostname }}.conf.part"
    when: (ansible_network_os is defined and ansible_network_os == "dellos6") and ((dellos_cfg_generate | default('False')) | bool)
 #   notify: save config os6
    register: generate_output

--- a/tasks/provision_dellos9.yaml
+++ b/tasks/provision_dellos9.yaml
@@ -3,7 +3,7 @@
  - name: "Generating ACL configuration for dellos9"
    template:
       src: dellos9_acl.j2
-      dest: "{{ build_dir }}/acl9_{{ hostname }}.conf.part"
+      dest: "{{ build_dir }}/acl9_{{ inventory_hostname }}.conf.part"
    when: (ansible_network_os is defined and ansible_network_os == "dellos9") and ((dellos_cfg_generate | default('False')) | bool)
 #   notify: save config os9
    register: generate_output


### PR DESCRIPTION
Ansible already populates a hostname in a variable, so use that one
instead of requiring users of this role to populate a variable in their
group_vars/all.yaml like:

        hostname: "{{ inventory_hostname }}"